### PR TITLE
:arrow_down: Downgraded intl dependency and remove unused one

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,8 +14,7 @@ dependencies:
   flutter:
     sdk: flutter
   freezed_annotation: ^2.4.1
-  intl: ^0.19.0
-  json_annotation: ^4.8.1
+  intl: ^0.18.0
   logging: ^1.2.0
 
 dev_dependencies:


### PR DESCRIPTION
 Downgraded intl dependency because flutter_localization uses lower version and remove unused one