### PR TITLE
:sparkles: Added addBetween iterable extension

### DIFF
--- a/lib/common/extensions/iterable.dart
+++ b/lib/common/extensions/iterable.dart
@@ -1,0 +1,12 @@
+import 'package:collection/collection.dart';
+
+/// Insert additional value into iterables.
+extension Insert<T> on Iterable<T> {
+  /// Insert [value] between each element of the iterable.
+  Iterable<T> addBetween(T value) {
+    return expandIndexed((int index, T element) sync* {
+      yield element;
+      if (index < length - 1) yield value;
+    });
+  }
+}

--- a/test/common/extensions/iterable_test.dart
+++ b/test/common/extensions/iterable_test.dart
@@ -1,0 +1,26 @@
+import 'package:dcc_toolkit/common/extensions/iterable.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:parameterized_test/parameterized_test.dart';
+
+void main() {
+  parameterizedTest2('addBetween tests', [
+    [
+      <int>[],
+      <int>[],
+    ],
+    [
+      [1],
+      [1],
+    ],
+    [
+      [1, 2],
+      [1, 0, 2],
+    ],
+    [
+      [1, 2, 3],
+      [1, 0, 2, 0, 3],
+    ],
+  ], (List<int> initial, List<int> expected) {
+    expect(initial.addBetween(0), expected);
+  });
+}


### PR DESCRIPTION
Adds addBetween extension on `Iterable` to easily insert items between other items.